### PR TITLE
Hide API secret keys in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
+
+# Gradle properties
+gradle.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ before_script:
     - adb shell input keyevent 82 &
     # Set `gradlew` as executable
     - chmod +x $TRAVIS_BUILD_DIR/android/gradlew
+    - cp $TRAVIS_BUILD_DIR/android/gradle.properties.no.git $TRAVIS_BUILD_DIR/android/gradle.properties
+    - sed -i "s/mykey/$API_KEY/g" $TRAVIS_BUILD_DIR/android/gradle.properties
+    - sed -i "s/mysecret/$API_SECRET/g" $TRAVIS_BUILD_DIR/android/gradle.properties
 
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ with Android Studio it will fail to compile. To achieve that you need to create 
 in the same directory and name it `gradle.properties`. Then you can insert in the newly created `gradle.properties`
 your secret API keys without having to version control them.
 
-This approach, will also work pn TravisCI which creates the `gradle.properties` file and sets the secret API credentials
+This approach, will also work on TravisCI which creates the `gradle.properties` file and sets the secret API credentials
 (if needed, e.g. for instrumented tests) via environment variables
 [defined in settings](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings).
 Please remember that if you need to make any version controlled changes to your `gradle.properties`, these need to be

--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ and if one of them fails it designates the entire build as unsuccessful.
 Each stage of the [job lifecycle](https://docs.travis-ci.com/user/job-lifecycle/) is rather excessively documented
 and explained, however especially the parts regarding the Android application are rather tricky and, sadly, tend
 to break upon the release of new API and SDK versions.
+
+### Compiling the Android app
+The Android application demonstrates how to (not) store secret API keys in a public repository, by keeping
+`gradle.properties` out of the version control system. This means that if you just open the application
+with Android Studio it will fail to compile. To achieve that you need to create a copy of `gradle.properties.no.git`
+in the same directory and name it `gradle.properties`. Then you can insert in the newly created `gradle.properties`
+your secret API keys without having to version control them.
+
+This approach, will also work pn TravisCI which creates the `gradle.properties` file and sets the secret API credentials
+(if needed, e.g. for instrumented tests) via environment variables
+[defined in settings](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings).
+Please remember that if you need to make any version controlled changes to your `gradle.properties`, these need to be
+made in its version controlled copy, i.e. `gradle.properties.no.git`.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,6 +15,11 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+
+        buildTypes.each {
+            it.buildConfigField 'String', 'apiKey', GoolgeAPIKey
+            it.buildConfigField 'String', 'apiSecret', GoogleAPISecret
+        }
     }
 }
 

--- a/android/app/src/main/java/platis/solutions/ci/example/MainActivity.java
+++ b/android/app/src/main/java/platis/solutions/ci/example/MainActivity.java
@@ -2,12 +2,22 @@ package platis.solutions.ci.example;
 
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.widget.TextView;
 
 public class MainActivity extends AppCompatActivity {
+
+    TextView mApiKeyField;
+    TextView mApiSecretField;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        mApiKeyField = findViewById(R.id.apiKeyText);
+        mApiSecretField = findViewById(R.id.apiSecretText);
+
+        mApiKeyField.setText("API key: " + BuildConfig.apiKey);
+        mApiSecretField.setText("API secret: " + BuildConfig.apiSecret);
     }
 }

--- a/android/app/src/main/java/platis/solutions/ci/example/MainActivity.java
+++ b/android/app/src/main/java/platis/solutions/ci/example/MainActivity.java
@@ -17,6 +17,13 @@ public class MainActivity extends AppCompatActivity {
         mApiKeyField = findViewById(R.id.apiKeyText);
         mApiSecretField = findViewById(R.id.apiSecretText);
 
+        // If you are getting a compilation error in the two lines below
+        // then you need make a copy of the `gradle.properties.no.git` file in the
+        // root of this application to the same folder and call it `gradle.properties`.
+        // There you can define your (secret) API keys without having to version control
+        // them. Please note that this is not how you should store keys for an
+        // application that will be distributed as an `.apk` since the keys can
+        // eventually be decompiled.
         mApiKeyField.setText("API key: " + BuildConfig.apiKey);
         mApiSecretField.setText("API secret: " + BuildConfig.apiSecret);
     }

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -6,13 +6,27 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
+        <TextView
+            android:id="@+id/topText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text= "@string/top_text" />
+
+        <TextView
+            android:id="@+id/apiKeyText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/api_key_text" />
+
+        <TextView
+            android:id="@+id/apiSecretText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/api_secret_text" />
+    </LinearLayout>
 </android.support.constraint.ConstraintLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">My Application</string>
+    <string name="top_text">Hello World!</string>
+    <string name="api_key_text">No API key found</string>
+    <string name="api_secret_text">No API Secret found</string>
+
 </resources>

--- a/android/gradle.properties.no.git
+++ b/android/gradle.properties.no.git
@@ -12,4 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-
+# Copy this file as `gradle.properties` into the same directory and make changes
+# to *the copy* that should *not* be version controlled.
+GoolgeAPIKey = "mykey"
+GoogleAPISecret = "mysecret"


### PR DESCRIPTION
An example on how to build an (open source) Android application with TravisCI.

Since we need to protect the API keys, we cannot version control them but need
to somehow provide them to the CI machine. We achieve this by editing them in
`gradle.properties` during the CI build.